### PR TITLE
Implement course filtering by active state in findAll()

### DIFF
--- a/.jhipster/Course.json
+++ b/.jhipster/Course.json
@@ -18,6 +18,10 @@
       "fieldType": "LocalDate"
     },
     {
+      "fieldName": "remainActiveOffset",
+      "fieldType": "Integer"
+    },
+    {
       "fieldName": "maxFoodSum",
       "fieldType": "Integer"
     },

--- a/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/Course.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/Course.java
@@ -57,7 +57,7 @@ public class Course implements Serializable {
     private LocalDate endDate;
 
     /**
-     * End date.
+     * How long to remain active for after end date.
      */
     @Column(name = "remain_active_offset")
     private Integer remainActiveOffset;

--- a/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/Course.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/Course.java
@@ -57,6 +57,12 @@ public class Course implements Serializable {
     private LocalDate endDate;
 
     /**
+     * End date.
+     */
+    @Column(name = "remain_active_offset")
+    private Integer remainActiveOffset;
+
+    /**
      * Max food sum for the course.
      */
     @Column(name = "max_food_sum")
@@ -152,6 +158,25 @@ public class Course implements Serializable {
     /**
      * Getter.
      *
+     * @return how long to remain active for after end date.
+     */
+    public Integer getRemainActiveOffset() {
+        return remainActiveOffset;
+    }
+
+    /**
+     * Setter.
+     *
+     * @param newRemainActiveOffset the new offset for remaining active after
+     *                              end date.
+     */
+    public void setRemainActiveOffset(final Integer newRemainActiveOffset) {
+        this.remainActiveOffset = newRemainActiveOffset;
+    }
+
+    /**
+     * Getter.
+     *
      * @return the maximum food sum.
      */
     public Integer getMaxFoodSum() {
@@ -222,6 +247,8 @@ public class Course implements Serializable {
             && Objects.equals(getName(), course.getName())
             && Objects.equals(getStartDate(), course.getStartDate())
             && Objects.equals(getEndDate(), course.getEndDate())
+            && Objects.equals(getRemainActiveOffset(),
+                                                course.getRemainActiveOffset())
             && Objects.equals(getMaxFoodSum(), course.getMaxFoodSum())
             && Objects.equals(getCourseDescription(),
             course.getCourseDescription())
@@ -239,6 +266,7 @@ public class Course implements Serializable {
             getName(),
             getStartDate(),
             getEndDate(),
+            getRemainActiveOffset(),
             getMaxFoodSum(),
             getCourseDescription(),
             getPublishState());
@@ -256,6 +284,7 @@ public class Course implements Serializable {
             + ", name='" + name + '\''
             + ", startDate=" + startDate
             + ", endDate=" + endDate
+            + ", remainActiveOffset= " + remainActiveOffset
             + ", maxFoodSum=" + maxFoodSum
             + ", courseDescription='" + courseDescription + '\''
             + ", publishState=" + publishState

--- a/src/main/java/de/uni_stuttgart/it_rex/course/repository/written/CourseRepository.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/repository/written/CourseRepository.java
@@ -1,13 +1,20 @@
 package de.uni_stuttgart.it_rex.course.repository.written;
 
-import de.uni_stuttgart.it_rex.course.domain.enumeration.PUBLISHSTATE;
 import de.uni_stuttgart.it_rex.course.domain.written.Course;
+import org.springframework.data.domain.Example;
+import org.springframework.data.jpa.convert.QueryByExamplePredicateBuilder;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import javax.persistence.criteria.Predicate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -15,15 +22,15 @@ import java.util.UUID;
  */
 @SuppressWarnings("unused")
 @Repository
-public interface CourseRepository extends JpaRepository<Course, UUID> {
+public interface CourseRepository extends JpaRepository<Course, UUID>,
+    JpaSpecificationExecutor<Course> {
 
     /**
      * Bla.
      *
      * @return List of courses
-     */
-    @Query(value = "SELECT * FROM course WHERE DATE(start_date) <= "
-        + "DATE(NOW()) AND DATE(end_date) >= DATE(NOW())",
+    */
+    @Query(value = "SELECT * FROM course WHERE end_date >= CURRENT_DATE()",
         nativeQuery = true)
     List<Course> findAllActive();
 
@@ -33,10 +40,9 @@ public interface CourseRepository extends JpaRepository<Course, UUID> {
      * @param publishState The publish state to search for.
      * @return List of courses
      */
-    @Query(value = "SELECT * FROM course WHERE DATE(start_date) <= "
-        + "DATE(NOW()) AND DATE(end_date) >= DATE(NOW()) "
-        + "AND publish_state = :publishState",
+    @Query(value = "SELECT * FROM course WHERE end_date >= CURRENT_DATE() "
+        + "AND publish_state = ?1",
         nativeQuery = true)
     List<Course> findAllActiveWithPublishState(@Param("publishState")
-                                               PUBLISHSTATE publishState);
+                                                   String publishState);
 }

--- a/src/main/java/de/uni_stuttgart/it_rex/course/repository/written/CourseRepository.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/repository/written/CourseRepository.java
@@ -1,20 +1,11 @@
 package de.uni_stuttgart.it_rex.course.repository.written;
 
 import de.uni_stuttgart.it_rex.course.domain.written.Course;
-import org.springframework.data.domain.Example;
-import org.springframework.data.jpa.convert.QueryByExamplePredicateBuilder;
-import org.springframework.data.jpa.domain.Specification;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import javax.persistence.criteria.Predicate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -23,26 +14,4 @@ import java.util.UUID;
 @SuppressWarnings("unused")
 @Repository
 public interface CourseRepository extends JpaRepository<Course, UUID>,
-    JpaSpecificationExecutor<Course> {
-
-    /**
-     * Bla.
-     *
-     * @return List of courses
-    */
-    @Query(value = "SELECT * FROM course WHERE end_date >= CURRENT_DATE()",
-        nativeQuery = true)
-    List<Course> findAllActive();
-
-    /**
-     * Bla.
-     *
-     * @param publishState The publish state to search for.
-     * @return List of courses
-     */
-    @Query(value = "SELECT * FROM course WHERE end_date >= CURRENT_DATE() "
-        + "AND publish_state = ?1",
-        nativeQuery = true)
-    List<Course> findAllActiveWithPublishState(@Param("publishState")
-                                                   String publishState);
-}
+    JpaSpecificationExecutor<Course> { }

--- a/src/main/java/de/uni_stuttgart/it_rex/course/repository/written/CourseRepository.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/repository/written/CourseRepository.java
@@ -1,9 +1,13 @@
 package de.uni_stuttgart.it_rex.course.repository.written;
 
+import de.uni_stuttgart.it_rex.course.domain.enumeration.PUBLISHSTATE;
 import de.uni_stuttgart.it_rex.course.domain.written.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -12,4 +16,27 @@ import java.util.UUID;
 @SuppressWarnings("unused")
 @Repository
 public interface CourseRepository extends JpaRepository<Course, UUID> {
+
+    /**
+     * Bla.
+     *
+     * @return List of courses
+     */
+    @Query(value = "SELECT * FROM course WHERE DATE(start_date) <= "
+        + "DATE(NOW()) AND DATE(end_date) >= DATE(NOW())",
+        nativeQuery = true)
+    List<Course> findAllActive();
+
+    /**
+     * Bla.
+     *
+     * @param publishState The publish state to search for.
+     * @return List of courses
+     */
+    @Query(value = "SELECT * FROM course WHERE DATE(start_date) <= "
+        + "DATE(NOW()) AND DATE(end_date) >= DATE(NOW()) "
+        + "AND publish_state = :publishState",
+        nativeQuery = true)
+    List<Course> findAllActiveWithPublishState(@Param("publishState")
+                                               PUBLISHSTATE publishState);
 }

--- a/src/main/java/de/uni_stuttgart/it_rex/course/service/written/CourseService.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/service/written/CourseService.java
@@ -42,7 +42,7 @@ public class CourseService {
      * Constructor.
      *
      * @param newCourseRepository the course repository.
-     * @param newCourseMapper the course mapper.
+     * @param newCourseMapper     the course mapper.
      */
     @Autowired
     public CourseService(final CourseRepository newCourseRepository,
@@ -120,17 +120,37 @@ public class CourseService {
      * Method finds all courses and filters them by given parameters.
      *
      * @param publishState Publish state of course.
+     * @param activeOnly   Set true to only include active courses (current time
+     *                     between course start and end date + offset).
      * @return A list of courses that fit the given parameters.
      */
     public List<Course> findAll(
-        final Optional<PUBLISHSTATE> publishState) {
+        final Optional<PUBLISHSTATE> publishState,
+        final Optional<Boolean> activeOnly) {
         LOGGER.debug("Request to get filtered Courses");
 
         LOGGER.trace("Applying filters.");
         Course courseExample = applyFiltersToExample(publishState);
 
-        return courseRepository
-            .findAll(Example.of(courseExample));
+        // man möge mir den umstand verzeihen, dass das oben in manchen fällen
+        // nicht verwendet wird und die folgenden zeilen das schönste
+        // sind, was ich in diesem projekt produziert habe </sarcasm>
+        // (konzeptcode ahead)
+
+        List<Course> courses = null;
+
+        if (activeOnly.isPresent()) {
+            courses = (
+                publishState.isPresent()
+                    ? courseRepository.findAllActiveWithPublishState(
+                        publishState.orElse(PUBLISHSTATE.PUBLISHED)
+                    )
+                    : courseRepository.findAllActive());
+        } else {
+            courses = courseRepository.findAll(Example.of(courseExample));
+        }
+
+        return courses;
     }
 
     /**

--- a/src/main/java/de/uni_stuttgart/it_rex/course/service/written/CourseService.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/service/written/CourseService.java
@@ -41,7 +41,7 @@ public class CourseService {
     /**
      * Course mapper.
      */
-    private CourseMapper courseMapper;
+    private final CourseMapper courseMapper;
 
     /**
      * Constructor.
@@ -135,9 +135,10 @@ public class CourseService {
         LOGGER.debug("Request to get filtered Courses");
         LOGGER.trace("Applying filters.");
 
-        List<Course> courses = null;
+        List<Course> courses;
 
-        Example courseExample = Example.of(applyFiltersToExample(publishState));
+        Example<Course> courseExample =
+            Example.of(applyFiltersToExample(publishState));
         Specification<Course> spec =
             getSpecFromActiveAndExample(activeOnly, courseExample);
         courses = courseRepository.findAll(spec);
@@ -172,7 +173,7 @@ public class CourseService {
      */
     private Specification<Course> getSpecFromActiveAndExample(
         final Optional<Boolean> activeOnly, final Example<Course> example) {
-        return (Specification<Course>) (root, query, builder) -> {
+        return (root, query, builder) -> {
 
             List<Predicate> predicates = new ArrayList<>();
 

--- a/src/main/java/de/uni_stuttgart/it_rex/course/web/rest/written/CourseResource.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/web/rest/written/CourseResource.java
@@ -1,6 +1,5 @@
 package de.uni_stuttgart.it_rex.course.web.rest.written;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import de.uni_stuttgart.it_rex.course.domain.enumeration.PUBLISHSTATE;
 import de.uni_stuttgart.it_rex.course.domain.written.Course;
 import de.uni_stuttgart.it_rex.course.service.written.CourseService;

--- a/src/main/java/de/uni_stuttgart/it_rex/course/web/rest/written/CourseResource.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/web/rest/written/CourseResource.java
@@ -1,5 +1,6 @@
 package de.uni_stuttgart.it_rex.course.web.rest.written;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import de.uni_stuttgart.it_rex.course.domain.enumeration.PUBLISHSTATE;
 import de.uni_stuttgart.it_rex.course.domain.written.Course;
 import de.uni_stuttgart.it_rex.course.service.written.CourseService;
@@ -171,15 +172,19 @@ public class CourseResource {
     /**
      * {@code GET  /courses} : get all the courses.
      * Filters them by the publish state if it exists.
+     * Optionally only select active courses.
      *
      * @param publishState Publish state of course.
+     * @param activeOnly Set true to only include active courses (current time
+     *                   between course start and end date + offset).
      * @return A list of courses that fit the given parameters.
      */
     @GetMapping("/courses")
     public List<Course> getAllCourses(
         @RequestParam("publishState") final Optional<PUBLISHSTATE>
-            publishState) {
+            publishState,
+        @RequestParam("activeOnly") final Optional<Boolean> activeOnly) {
         log.debug("REST request to get filtered Courses");
-        return courseService.findAll(publishState);
+        return courseService.findAll(publishState, activeOnly);
     }
 }

--- a/src/main/resources/config/liquibase/changelog/20210113223125_added_entity_Course.xml
+++ b/src/main/resources/config/liquibase/changelog/20210113223125_added_entity_Course.xml
@@ -22,6 +22,9 @@
             <column name="end_date" type="date">
                 <constraints nullable="true" />
             </column>
+            <column name="remain_active_offset" type="integer">
+                <constraints nullable="true" />
+            </column>
             <column name="max_food_sum" type="integer">
                 <constraints nullable="true" />
             </column>

--- a/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/CourseTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/CourseTest.java
@@ -25,6 +25,9 @@ class CourseTest {
     private static final LocalDate FIRST_END_DATE = LocalDate.ofEpochDay(0L);
     private static final LocalDate SECOND_END_DATE = LocalDate.now(ZoneId.systemDefault());
 
+    private static final Integer FIRST_REMAIN_ACTIVE_OFFSET = 0;
+    private static final Integer SECOND_REMAIN_ACTIVE_OFFSET = 1;
+
     private static final Integer FIRST_MAX_FOOD_SUM = 1;
     private static final Integer SECOND_MAX_FOOD_SUM = 2;
 
@@ -42,6 +45,7 @@ class CourseTest {
         course1.setName(FIRST_NAME);
         course1.setStartDate(FIRST_START_DATE);
         course1.setEndDate(FIRST_END_DATE);
+        course1.setRemainActiveOffset(FIRST_REMAIN_ACTIVE_OFFSET);
         course1.setMaxFoodSum(FIRST_MAX_FOOD_SUM);
         course1.setCourseDescription(FIRST_COURSE_DESCRIPTION);
         course1.setPublishState(FIRST_PUBLISH_STATE);
@@ -51,6 +55,7 @@ class CourseTest {
         course2.setName(SECOND_NAME);
         course2.setStartDate(SECOND_START_DATE);
         course2.setEndDate(SECOND_END_DATE);
+        course2.setRemainActiveOffset(SECOND_REMAIN_ACTIVE_OFFSET);
         course2.setMaxFoodSum(SECOND_MAX_FOOD_SUM);
         course2.setCourseDescription(SECOND_COURSE_DESCRIPTION);
         course2.setPublishState(SECOND_PUBLISH_STATE);
@@ -60,6 +65,7 @@ class CourseTest {
         course3.setName(FIRST_NAME);
         course3.setStartDate(FIRST_START_DATE);
         course3.setEndDate(FIRST_END_DATE);
+        course3.setRemainActiveOffset(FIRST_REMAIN_ACTIVE_OFFSET);
         course3.setMaxFoodSum(FIRST_MAX_FOOD_SUM);
         course3.setCourseDescription(FIRST_COURSE_DESCRIPTION);
         course3.setPublishState(FIRST_PUBLISH_STATE);

--- a/src/test/java/de/uni_stuttgart/it_rex/course/web/rest/written/CourseResourceIT.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/course/web/rest/written/CourseResourceIT.java
@@ -51,6 +51,9 @@ public class CourseResourceIT {
     private static final LocalDate DEFAULT_END_DATE = LocalDate.ofEpochDay(0L);
     private static final LocalDate UPDATED_END_DATE = LocalDate.now(ZoneId.systemDefault());
 
+    private static final Integer DEFAULT_REMAIN_ACTIVE_OFFSET = 0;
+    private static final Integer UPDATED_REMAIN_ACTIVE_OFFSET = 1;
+
     private static final Integer DEFAULT_MAX_FOOD_SUM = 1;
     private static final Integer UPDATED_MAX_FOOD_SUM = 2;
 
@@ -69,6 +72,8 @@ public class CourseResourceIT {
 
     private static final String NEW_DESCRIPTION = "Really cool Course";
     private static final PUBLISHSTATE NEW_PUBLISHED_STATE = PUBLISHSTATE.PUBLISHED;
+
+    private static final LocalDate NEW_END_DATE = LocalDate.ofEpochDay(LocalDate.now().toEpochDay() + 1);
 
     @Autowired
     private CourseRepository courseRepository;
@@ -98,6 +103,7 @@ public class CourseResourceIT {
         course.setName(DEFAULT_NAME);
         course.setStartDate(DEFAULT_START_DATE);
         course.setEndDate(DEFAULT_END_DATE);
+        course.setRemainActiveOffset(DEFAULT_REMAIN_ACTIVE_OFFSET);
         course.setMaxFoodSum(DEFAULT_MAX_FOOD_SUM);
         course.setCourseDescription(DEFAULT_COURSE_DESCRIPTION);
         course.setPublishState(DEFAULT_PUBLISH_STATE);
@@ -114,6 +120,7 @@ public class CourseResourceIT {
         course.setName(UPDATED_NAME);
         course.setStartDate(UPDATED_START_DATE);
         course.setEndDate(UPDATED_END_DATE);
+        course.setRemainActiveOffset(UPDATED_REMAIN_ACTIVE_OFFSET);
         course.setMaxFoodSum(UPDATED_MAX_FOOD_SUM);
         course.setCourseDescription(UPDATED_COURSE_DESCRIPTION);
         course.setPublishState(UPDATED_PUBLISH_STATE);
@@ -142,6 +149,7 @@ public class CourseResourceIT {
         assertThat(testCourse.getName()).isEqualTo(DEFAULT_NAME);
         assertThat(testCourse.getStartDate()).isEqualTo(DEFAULT_START_DATE);
         assertThat(testCourse.getEndDate()).isEqualTo(DEFAULT_END_DATE);
+        assertThat(testCourse.getRemainActiveOffset()).isEqualTo(DEFAULT_REMAIN_ACTIVE_OFFSET);
         assertThat(testCourse.getMaxFoodSum()).isEqualTo(DEFAULT_MAX_FOOD_SUM);
         assertThat(testCourse.getCourseDescription()).isEqualTo(DEFAULT_COURSE_DESCRIPTION);
         assertThat(testCourse.getPublishState()).isEqualTo(DEFAULT_PUBLISH_STATE);
@@ -181,6 +189,7 @@ public class CourseResourceIT {
             .andExpect(jsonPath("$.[*].name").value(hasItem(DEFAULT_NAME)))
             .andExpect(jsonPath("$.[*].startDate").value(hasItem(DEFAULT_START_DATE.toString())))
             .andExpect(jsonPath("$.[*].endDate").value(hasItem(DEFAULT_END_DATE.toString())))
+            .andExpect(jsonPath("$.[*].remainActiveOffset").value(hasItem(DEFAULT_REMAIN_ACTIVE_OFFSET)))
             .andExpect(jsonPath("$.[*].maxFoodSum").value(hasItem(DEFAULT_MAX_FOOD_SUM)))
             .andExpect(jsonPath("$.[*].courseDescription").value(hasItem(DEFAULT_COURSE_DESCRIPTION.toString())))
             .andExpect(jsonPath("$.[*].publishState").value(hasItem(DEFAULT_PUBLISH_STATE.toString())));
@@ -200,6 +209,7 @@ public class CourseResourceIT {
             .andExpect(jsonPath("$.name").value(DEFAULT_NAME))
             .andExpect(jsonPath("$.startDate").value(DEFAULT_START_DATE.toString()))
             .andExpect(jsonPath("$.endDate").value(DEFAULT_END_DATE.toString()))
+            .andExpect(jsonPath("$.remainActiveOffset").value(DEFAULT_REMAIN_ACTIVE_OFFSET))
             .andExpect(jsonPath("$.maxFoodSum").value(DEFAULT_MAX_FOOD_SUM))
             .andExpect(jsonPath("$.courseDescription").value(DEFAULT_COURSE_DESCRIPTION.toString()))
             .andExpect(jsonPath("$.publishState").value(DEFAULT_PUBLISH_STATE.toString()));
@@ -228,6 +238,7 @@ public class CourseResourceIT {
         updatedCourse.setName(UPDATED_NAME);
         updatedCourse.setStartDate(UPDATED_START_DATE);
         updatedCourse.setEndDate(UPDATED_END_DATE);
+        updatedCourse.setRemainActiveOffset(UPDATED_REMAIN_ACTIVE_OFFSET);
         updatedCourse.setMaxFoodSum(UPDATED_MAX_FOOD_SUM);
         updatedCourse.setCourseDescription(UPDATED_COURSE_DESCRIPTION);
         updatedCourse.setPublishState(UPDATED_PUBLISH_STATE);
@@ -244,6 +255,7 @@ public class CourseResourceIT {
         assertThat(testCourse.getName()).isEqualTo(UPDATED_NAME);
         assertThat(testCourse.getStartDate()).isEqualTo(UPDATED_START_DATE);
         assertThat(testCourse.getEndDate()).isEqualTo(UPDATED_END_DATE);
+        assertThat(testCourse.getRemainActiveOffset()).isEqualTo(UPDATED_REMAIN_ACTIVE_OFFSET);
         assertThat(testCourse.getMaxFoodSum()).isEqualTo(UPDATED_MAX_FOOD_SUM);
         assertThat(testCourse.getCourseDescription()).isEqualTo(UPDATED_COURSE_DESCRIPTION);
         assertThat(testCourse.getPublishState()).isEqualTo(UPDATED_PUBLISH_STATE);
@@ -293,7 +305,7 @@ public class CourseResourceIT {
 
         // Get all the courseList
         restCourseMockMvc
-            .perform(get("/api/courses?publishState=PUBLISHED")
+            .perform(get("/api/courses?publishState=PUBLISHED&activeOnly=false")
                 .param("publishState", publishState))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -301,6 +313,40 @@ public class CourseResourceIT {
             .andExpect(jsonPath("$.[*].name").value(hasItem(DEFAULT_NAME)))
             .andExpect(jsonPath("$.[*].startDate").value(hasItem(DEFAULT_START_DATE.toString())))
             .andExpect(jsonPath("$.[*].endDate").value(hasItem(DEFAULT_END_DATE.toString())))
+            .andExpect(jsonPath("$.[*].remainActiveOffset").value(hasItem(DEFAULT_REMAIN_ACTIVE_OFFSET)))
+            .andExpect(jsonPath("$.[*].maxFoodSum").value(hasItem(DEFAULT_MAX_FOOD_SUM)))
+            .andExpect(jsonPath("$.[*].courseDescription").value(hasItem(DEFAULT_COURSE_DESCRIPTION)))
+            .andExpect(jsonPath("$.[*].publishState").value(hasItem(DEFAULT_PUBLISH_STATE.toString())));
+    }
+
+    @Test
+    @Transactional
+    void getFilteredActiveCourses() throws Exception {
+        String publishState = "PUBLISHED";
+
+        // Initialize the database
+        courseRepository.saveAndFlush(course);
+
+        // Get all the courseList
+        restCourseMockMvc
+            .perform(get("/api/courses?publishState=PUBLISHED&activeOnly=true")
+                .param("publishState", publishState))
+            .andExpect(status().isOk())
+            .andExpect(content().string("[]"));
+
+        course.setEndDate(NEW_END_DATE);
+        courseRepository.saveAndFlush(course);
+
+        restCourseMockMvc
+            .perform(get("/api/courses?publishState=PUBLISHED&activeOnly=true")
+                .param("publishState", publishState))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(course.getId().toString())))
+            .andExpect(jsonPath("$.[*].name").value(hasItem(DEFAULT_NAME)))
+            .andExpect(jsonPath("$.[*].startDate").value(hasItem(DEFAULT_START_DATE.toString())))
+            .andExpect(jsonPath("$.[*].endDate").value(hasItem(NEW_END_DATE.toString())))
+            .andExpect(jsonPath("$.[*].remainActiveOffset").value(hasItem(DEFAULT_REMAIN_ACTIVE_OFFSET)))
             .andExpect(jsonPath("$.[*].maxFoodSum").value(hasItem(DEFAULT_MAX_FOOD_SUM)))
             .andExpect(jsonPath("$.[*].courseDescription").value(hasItem(DEFAULT_COURSE_DESCRIPTION)))
             .andExpect(jsonPath("$.[*].publishState").value(hasItem(DEFAULT_PUBLISH_STATE.toString())));

--- a/src/test/resources/postman/Course.json
+++ b/src/test/resources/postman/Course.json
@@ -3,6 +3,7 @@
   "name": "Cooler Kurs",
   "startDate": "2019-09-20",
   "endDate": "2222-02-22",
+  "remainActiveOffset": 0,
   "maxFoodSum": 4242,
   "courseDescription": null,
   "publishState": "PUBLISHED"

--- a/src/test/resources/postman/course-service.postman_collection.json
+++ b/src/test/resources/postman/course-service.postman_collection.json
@@ -62,7 +62,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"name\": \"Cooler Kurs\",\n  \"startDate\": \"2019-09-20\",\n  \"endDate\": \"2222-02-22\",\n  \"maxFoodSum\": 4242,\n  \"courseDescription\": null,\n  \"publishState\": \"PUBLISHED\"\n}\n",
+					"raw": "{\n  \"name\": \"Cooler Kurs\",\n  \"startDate\": \"2019-09-20\",\n  \"endDate\": \"2222-02-22\",\n  \"remainActiveOffset\": 0,\n  \"maxFoodSum\": 4242,\n  \"courseDescription\": null,\n  \"publishState\": \"PUBLISHED\"\n}\n",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
This PR also adds the remainActiveOffset attribute in the Course domain object, however there's no real functionality tied to that yet as we might have to decide first on how we want to use that precisely.

Also: I wasn't able to view course pages on this branch. Not sure if it's the new attribute 'remainActiveOffset' that's missing in the Frontend interfaces or what, but I couldn't fix it myself by introducing it in my local Frontend copy so it might as well be an unrelated issue. (Paging @nemampojma5 and @katja-seb for that reason.)