### PR TITLE
ITREX-593: Fix equals and hashcode functions for entities

### DIFF
--- a/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/Chapter.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/Chapter.java
@@ -18,10 +18,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * A Chapter.
@@ -176,7 +173,7 @@ public class Chapter implements Serializable {
         if (newContentReferences == null) {
             return;
         }
-        for (ContentReference c : newContentReferences){
+        for (ContentReference c : newContentReferences) {
             addContentReference(c);
         }
     }
@@ -216,12 +213,14 @@ public class Chapter implements Serializable {
 
     /**
      * Equals method.
+     * <p>
+     * Only compare the Id (primary key) here as Hibernate handles the rest.
      *
      * @param o the other instance.
      * @return if they are equal.
      */
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
@@ -229,21 +228,20 @@ public class Chapter implements Serializable {
             return false;
         }
         Chapter chapter = (Chapter) o;
-        return chapterNumber == chapter.chapterNumber &&
-            id.equals(chapter.id) &&
-            Objects.equals(name, chapter.name) &&
-            course.equals(chapter.course) && Objects
-            .equals(contentReferences, chapter.contentReferences);
+        return id != null && id.equals(chapter.getId());
     }
 
     /**
      * Hash code.
+     * <p>
+     * Use a constant value here because the Id is generated and set when
+     * persisting and can be null before that.
      *
      * @return the hash code.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, chapterNumber, course, contentReferences);
+        return 13;
     }
 
     /**

--- a/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/ContentReference.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/ContentReference.java
@@ -14,7 +14,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -177,11 +176,13 @@ public class ContentReference implements Serializable {
     /**
      * Equals method.
      *
+     * Only compare the Id (primary key) here as Hibernate handles the rest.
+     *
      * @param o the other instance.
      * @return if they are equal.
      */
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
@@ -189,22 +190,20 @@ public class ContentReference implements Serializable {
             return false;
         }
         ContentReference that = (ContentReference) o;
-        return index == that.index && id.equals(that.id) &&
-            contentId.equals(that.contentId) &&
-            contentReferenceType == that.contentReferenceType &&
-            chapter.equals(that.chapter) &&
-            Objects.equals(timePeriod, that.timePeriod);
+        return id != null && id.equals(that.getId());
     }
 
     /**
      * Hash code.
      *
+     * Use a constant value here because the Id is generated and set when
+     * persisting and can be null before that.
+     *
      * @return the hash code.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(id, index, contentId, contentReferenceType, chapter,
-            timePeriod);
+        return 13;
     }
 
     /**

--- a/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/Course.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/Course.java
@@ -22,7 +22,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -387,11 +386,13 @@ public class Course implements Serializable {
     /**
      * Equals method.
      *
+     * Only compare the Id (primary key) here as Hibernate handles the rest.
+     *
      * @param o the other instance.
      * @return if they are equal.
      */
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
@@ -399,30 +400,20 @@ public class Course implements Serializable {
             return false;
         }
         Course course = (Course) o;
-        return id.equals(course.id) &&
-            Objects.equals(name, course.name) &&
-            Objects.equals(startDate, course.startDate) &&
-            Objects.equals(endDate, course.endDate) &&
-            Objects
-                .equals(remainActiveOffset, course.remainActiveOffset) &&
-            Objects.equals(maxFoodSum, course.maxFoodSum) &&
-            Objects
-                .equals(courseDescription, course.courseDescription) &&
-            publishState == course.publishState &&
-            Objects.equals(timePeriods, course.timePeriods) &&
-            Objects.equals(chapters, course.chapters);
+        return id != null && id.equals(course.getId());
     }
 
     /**
      * Hash code.
      *
+     * Use a constant value here because the Id is generated and set when
+     * persisting and can be null before that.
+     *
      * @return the hash code.
      */
     @Override
     public int hashCode() {
-        return Objects
-            .hash(id, name, startDate, endDate, remainActiveOffset, maxFoodSum,
-                courseDescription, publishState, timePeriods, chapters);
+        return 13;
     }
 
     /**

--- a/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/TimePeriod.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/course/domain/written/TimePeriod.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -205,11 +204,13 @@ public class TimePeriod implements Serializable {
     /**
      * Equals method.
      *
+     * Only compare the Id (primary key) here as Hibernate handles the rest.
+     *
      * @param o the other instance.
      * @return if they are equal.
      */
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
@@ -217,20 +218,20 @@ public class TimePeriod implements Serializable {
             return false;
         }
         TimePeriod that = (TimePeriod) o;
-        return id.equals(that.id) && startDate.equals(that.startDate) &&
-            endDate.equals(that.endDate) && Objects
-            .equals(contentReferences, that.contentReferences) &&
-            course.equals(that.course);
+        return id != null && id.equals(that.getId());
     }
 
     /**
      * Hash code.
      *
+     * Use a constant value here because the Id is generated and set when
+     * persisting and can be null before that.
+     *
      * @return the hash code.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(id, startDate, endDate, contentReferences, course);
+        return 13;
     }
 
     /**

--- a/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/ChapterTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/ChapterTest.java
@@ -3,61 +3,47 @@ package de.uni_stuttgart.it_rex.course.domain.written;
 import de.uni_stuttgart.it_rex.course.utils.written.ChapterUtil;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public class ChapterTest {private static final UUID FIRST_ID = UUID.randomUUID();
-  private static final UUID SECOND_ID = UUID.randomUUID();
+class ChapterTest {
+    private static final UUID FIRST_ID = UUID.randomUUID();
+    private static final UUID SECOND_ID = UUID.randomUUID();
 
-  private static final String FIRST_NAME = "AAAAAAAAAA";
-  private static final String SECOND_NAME = "BBBBBBBBBB";
+    private static final String FIRST_NAME = "AAAAAAAAAA";
+    private static final String SECOND_NAME = "BBBBBBBBBB";
 
-  private static final LocalDate FIRST_START_DATE = LocalDate.ofEpochDay(0L);
-  private static final LocalDate SECOND_START_DATE = LocalDate.now(ZoneId.systemDefault());
+    private static final UUID FIRST_COURSE_ID = UUID.randomUUID();
+    private static final UUID SECOND_COURSE_ID = UUID.randomUUID();
 
-  private static final LocalDate FIRST_END_DATE = LocalDate.ofEpochDay(0L);
-  private static final LocalDate SECOND_END_DATE = LocalDate.now(ZoneId.systemDefault());
+    private static final UUID FIRST_NEXT = UUID.randomUUID();
+    private static final UUID SECOND_NEXT = UUID.randomUUID();
 
-  private static final UUID FIRST_COURSE_ID = UUID.randomUUID();
-  private static final UUID SECOND_COURSE_ID = UUID.randomUUID();
+    private static final UUID FIRST_PREVIOUS = UUID.randomUUID();
+    private static final UUID SECOND_PREVIOUS = UUID.randomUUID();
 
-  private static final UUID FIRST_NEXT = UUID.randomUUID();
-  private static final UUID SECOND_NEXT = UUID.randomUUID();
+    @Test
+    void equalsVerifier() {
 
-  private static final UUID FIRST_PREVIOUS =UUID.randomUUID();
-  private static final UUID SECOND_PREVIOUS = UUID.randomUUID();
+        Chapter chapter1 = new Chapter();
+        chapter1.setId(FIRST_ID);
+        chapter1.setName(FIRST_NAME);
 
-  @Test
-  void equalsVerifier() throws Exception {
+        Chapter chapter2 = new Chapter();
+        chapter2.setId(SECOND_ID);
+        chapter2.setName(SECOND_NAME);
 
-    Chapter chapter1 = new Chapter();
-    chapter1.setId(FIRST_ID);
-    chapter1.setName(FIRST_NAME);
-  // chapter1.setStartDate(FIRST_START_DATE);
-  // chapter1.setEndDate(FIRST_END_DATE);
+        Chapter chapter3 = new Chapter();
+        chapter3.setId(FIRST_ID);
+        chapter3.setName(FIRST_NAME);
 
-    Chapter chapter2 = new Chapter();
-    chapter2.setId(SECOND_ID);
-    chapter2.setName(SECOND_NAME);
-   // chapter2.setStartDate(SECOND_START_DATE);
-   // chapter2.setEndDate(SECOND_END_DATE);
+        assertEquals(chapter1.hashCode(), chapter1.hashCode());
+        assertEquals(chapter1, chapter1);
 
-    Chapter chapter3 = new Chapter();
-    chapter3.setId(FIRST_ID);
-    chapter3.setName(FIRST_NAME);
- //   chapter3.setStartDate(FIRST_START_DATE);
- //   chapter3.setEndDate(FIRST_END_DATE);
+        ChapterUtil.equalsChapter(chapter1, chapter3);
 
-    assertEquals(chapter1.hashCode(), chapter1.hashCode());
-    assertEquals(chapter1, chapter1);
-    ChapterUtil.equalsChapter(chapter1, chapter3);
-    assertNotEquals(chapter1, chapter2);
-    assertNotEquals(chapter1.hashCode(), chapter2.hashCode());
-
-    assertNotEquals(SECOND_NEXT, chapter1);
-  }
+        assertNotEquals(chapter1, chapter2);
+    }
 }

--- a/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/ContentReferenceTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/ContentReferenceTest.java
@@ -1,0 +1,58 @@
+package de.uni_stuttgart.it_rex.course.domain.written;
+
+import de.uni_stuttgart.it_rex.course.domain.enumeration.CONTENTREFERENCETYPE;
+import de.uni_stuttgart.it_rex.course.utils.written.ContentReferenceUtil;
+import de.uni_stuttgart.it_rex.course.utils.written.EnumUtil;
+import de.uni_stuttgart.it_rex.course.utils.written.NumbersUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ContentReferenceTest {
+    private static final UUID FIRST_ID = UUID.randomUUID();
+    private static final UUID SECOND_ID = UUID.randomUUID();
+
+    private static final int FIRST_INDEX =
+        NumbersUtil.generateRandomInteger(0, 1000);
+    private static final int SECOND_INDEX =
+        NumbersUtil.generateRandomInteger(0, 1000);
+
+    private static final UUID FIRST_CONTENT_ID = UUID.randomUUID();
+    private static final UUID SECOND_CONTENT_ID = UUID.randomUUID();
+
+    private static final CONTENTREFERENCETYPE FIRST_CONTENT_REFERENCE_TYPE =
+        EnumUtil.generateRandomContentReferenceType();
+    private static final CONTENTREFERENCETYPE SECOND_CONTENT_REFERENCE_TYPE =
+        EnumUtil.generateRandomContentReferenceType();
+
+    @Test
+    void equalsVerifier() throws Exception {
+        ContentReference cr1 = new ContentReference();
+        cr1.setId(FIRST_ID);
+        cr1.setIndex(FIRST_INDEX);
+        cr1.setContentId(FIRST_CONTENT_ID);
+        cr1.setContentReferenceType(FIRST_CONTENT_REFERENCE_TYPE);
+
+        ContentReference cr2  = new ContentReference();
+        cr2.setId(SECOND_ID);
+        cr2.setIndex(SECOND_INDEX);
+        cr2.setContentId(SECOND_CONTENT_ID);
+        cr2.setContentReferenceType(SECOND_CONTENT_REFERENCE_TYPE);
+
+        ContentReference cr3 = new ContentReference();
+        cr3.setId(FIRST_ID);
+        cr3.setIndex(FIRST_INDEX);
+        cr3.setContentId(FIRST_CONTENT_ID);
+        cr3.setContentReferenceType(FIRST_CONTENT_REFERENCE_TYPE);
+
+        assertEquals(cr1.hashCode(), cr1.hashCode());
+        assertEquals(cr1, cr1);
+
+        ContentReferenceUtil.equalsContentReference(cr1, cr3);
+
+        assertNotEquals(cr1, cr2);
+    }
+}

--- a/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/CourseTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/CourseTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 
 class CourseTest {
-
     private static final UUID FIRST_ID = UUID.randomUUID();
     private static final UUID SECOND_ID = UUID.randomUUID();
 
@@ -20,10 +19,12 @@ class CourseTest {
     private static final String SECOND_NAME = "BBBBBBBBBB";
 
     private static final LocalDate FIRST_START_DATE = LocalDate.ofEpochDay(0L);
-    private static final LocalDate SECOND_START_DATE = LocalDate.now(ZoneId.systemDefault());
+    private static final LocalDate SECOND_START_DATE =
+        LocalDate.now(ZoneId.systemDefault());
 
     private static final LocalDate FIRST_END_DATE = LocalDate.ofEpochDay(0L);
-    private static final LocalDate SECOND_END_DATE = LocalDate.now(ZoneId.systemDefault());
+    private static final LocalDate SECOND_END_DATE =
+        LocalDate.now(ZoneId.systemDefault());
 
     private static final Integer FIRST_REMAIN_ACTIVE_OFFSET = 0;
     private static final Integer SECOND_REMAIN_ACTIVE_OFFSET = 1;
@@ -34,11 +35,13 @@ class CourseTest {
     private static final String FIRST_COURSE_DESCRIPTION = "AAAAAAAAAA";
     private static final String SECOND_COURSE_DESCRIPTION = "BBBBBBBBBB";
 
-    private static final PUBLISHSTATE FIRST_PUBLISH_STATE = PUBLISHSTATE.PUBLISHED;
-    private static final PUBLISHSTATE SECOND_PUBLISH_STATE = PUBLISHSTATE.UNPUBLISHED;
+    private static final PUBLISHSTATE FIRST_PUBLISH_STATE =
+        PUBLISHSTATE.PUBLISHED;
+    private static final PUBLISHSTATE SECOND_PUBLISH_STATE =
+        PUBLISHSTATE.UNPUBLISHED;
 
     @Test
-    void equalsVerifier() throws Exception {
+    void equalsVerifier() {
 
         Course course1 = new Course();
         course1.setId(FIRST_ID);
@@ -72,10 +75,9 @@ class CourseTest {
 
         assertEquals(course1.hashCode(), course1.hashCode());
         assertEquals(course1, course1);
-        assertEquals(course1, course3);
-        assertNotEquals(course1, course2);
-        assertNotEquals(course1.hashCode(), course2.hashCode());
 
-        assertNotEquals(SECOND_COURSE_DESCRIPTION, course1);
+        assertEquals(course1, course3);
+
+        assertNotEquals(course1, course2);
     }
 }

--- a/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/TimePeriodTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/course/domain/written/TimePeriodTest.java
@@ -1,0 +1,50 @@
+package de.uni_stuttgart.it_rex.course.domain.written;
+
+import de.uni_stuttgart.it_rex.course.utils.written.TimePeriodUtil;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class TimePeriodTest {
+    private static final UUID FIRST_ID = UUID.randomUUID();
+    private static final UUID SECOND_ID = UUID.randomUUID();
+
+    private static final LocalDate FIRST_START_DATE = LocalDate.ofEpochDay(0L);
+    private static final LocalDate SECOND_START_DATE =
+        LocalDate.now(ZoneId.systemDefault());
+
+    private static final LocalDate FIRST_END_DATE = LocalDate.ofEpochDay(0L);
+    private static final LocalDate SECOND_END_DATE =
+        LocalDate.now(ZoneId.systemDefault());
+
+    @Test
+    void equalsVerifier() {
+
+        TimePeriod timePeriod1 = new TimePeriod();
+        timePeriod1.setId(FIRST_ID);
+        timePeriod1.setStartDate(FIRST_START_DATE);
+        timePeriod1.setEndDate(FIRST_END_DATE);
+
+        TimePeriod timePeriod2 = new TimePeriod();
+        timePeriod2.setId(SECOND_ID);
+        timePeriod2.setStartDate(SECOND_START_DATE);
+        timePeriod2.setEndDate(SECOND_END_DATE);
+
+        TimePeriod timePeriod3 = new TimePeriod();
+        timePeriod3.setId(FIRST_ID);
+        timePeriod3.setStartDate(FIRST_START_DATE);
+        timePeriod3.setEndDate(FIRST_END_DATE);
+
+        assertEquals(timePeriod1.hashCode(), timePeriod1.hashCode());
+        assertEquals(timePeriod1, timePeriod1);
+
+        TimePeriodUtil.equalsTimePeriod(timePeriod1, timePeriod3);
+
+        assertNotEquals(timePeriod1, timePeriod2);
+    }
+}


### PR DESCRIPTION
Habe mich an folgendem Artikel orientiert: https://thorben-janssen.com/ultimate-guide-to-implementing-equals-and-hashcode-with-hibernate/

Ich meine den haben wir damals auch benutzt. Auf uns trifft vor Allem der Absatz "Using a Generated Primary Key" zu (etwas runterscrollen). Danach hab ich in equlas Methoden nur noch die Id benutzt, in hashcode aber ne konstante "13". Bitte überprüfen ob das so passt. Dadurch ist der hashcode jetzt immer gleich.

Außerdem hab ich noch Tests für TimePeriod und ContentReference entities hinzugefügt.