### PR TITLE
Removed unnecessary jenkins stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,35 +9,16 @@ pipeline {
     agent { label agentLabel }
 
     stages {
-        stage('check java') {
-            steps {
-                sh 'java -version'
-            }
-        }
-
         stage('clean') {
             steps { sh 'chmod +x gradlew'
                 sh './gradlew clean --no-daemon'
             }
         }
 
-        stage('nohttp') {
-            steps {
-                sh './gradlew checkstyleNohttp --no-daemon'
-            }
-        }
-
-        stage('backend tests') {
+        stage('tests') {
             steps {
                 sh './gradlew check jacocoTestReport -PnodeInstall --no-daemon'
                 junit '**/build/**/TEST-*.xml'
-            }
-        }
-
-        stage('packaging') {
-            steps {
-                sh './gradlew bootJar -x test -Pprod -PnodeInstall --no-daemon'
-                archiveArtifacts artifacts: '**/build/libs/*.jar', fingerprint: true
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,15 +51,5 @@ pipeline {
                 sh 'docker-compose up -d --build --remove-orphans'
             }
         }
-
-        stage('release') {
-            when { allOf { branch 'dev'; triggeredBy 'UserIdCause' } }
-            steps {
-                sshagent (credentials: ['jenkins']) {
-                    echo 'Pushing dev to main'
-                    sh 'git push git@github.com:IT-REX-Platform/CourseService.git dev:main'
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
I removed a few pipeline stages:
- Checking the java version is bloat
- The nohttp stage does something with Checkstyle. We already do that in the quality analysis. The stage has never failed anyway ¯\_(ツ)_/¯
- The packaging stage builds the backend as a jar. We don't use those and the service is checked for compilability in the test stage anyway.
- Also removed the release stage